### PR TITLE
fix(coc-syntax): default null for filetypes

### DIFF
--- a/packages/syntax/package.json
+++ b/packages/syntax/package.json
@@ -52,6 +52,7 @@
           "items": {
             "type": "string"
           },
+          "default": null,
           "description": "Enabled filetypes, default enabled for all filetypes."
         }
       }


### PR DESCRIPTION
closes #73