### PR TITLE
feat(coc-dictionary): adapt first char case when necessary

### DIFF
--- a/packages/dictionary/index.js
+++ b/packages/dictionary/index.js
@@ -67,8 +67,14 @@ function filterWords(words, opt) {
   let res = []
   let { input } = opt
   for (let word of words) {
-    if (!word.startsWith(input[0])) continue
     if (word.length <= input.length) continue
+    let first = input[0]
+    if ([input, word].every(str => /^[A-Za-z]{1,}$/.test(str))) {
+      if (!word.startsWith(first.toLowerCase())) continue
+      let code = first.charCodeAt(0)
+      let upperCase = code <= 90 && code >= 65
+      word = upperCase ? word[0].toUpperCase() + word.slice(1) : word
+    } else if (!word.startsWith(first)) continue
     res.push(word)
   }
   return res


### PR DESCRIPTION
This makes `coc-dictionary` adapt the first char case for candidate words to match the case of the user's typed text. The change is made with [implementation of similar behaviour in coc-word](https://github.com/tanloong/coc-sources/blob/a442b16cd906ae17c117f159d2b289f17538fc24/packages/word/index.js#L17C1-L32C8) as a reference.

This partially addresses behavior requested by #67, although not taking `infercase` and `ignorecase` as on/off flags. One drawback is that for full upper case words, still only the first char of candidate words will be adapted, e.g., `zeal` will be adapted to `Zeal` as candidate for `ZEAL`. 

Before (no suggestions for upper case `Z`):

https://github.com/neoclide/coc-sources/assets/71320000/2517cf45-7f59-4da0-9e21-7059a8c28d4b



After:

https://github.com/neoclide/coc-sources/assets/71320000/7966f265-7166-4b6e-bc9d-c397203659f5



